### PR TITLE
Add support for exposing key-value pairs (implements #7)

### DIFF
--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -34,8 +34,8 @@ type Exporter struct {
 	nodeCount, serviceCount                           prometheus.Counter
 	serviceNodesTotal, serviceNodesHealthy, keyValues *prometheus.GaugeVec
 	client                                            *consul_api.Client
-	kvPrefix					  string
-	kvFilter					  *regexp.Regexp
+	kvPrefix                                          string
+	kvFilter                                          *regexp.Regexp
 }
 
 // NewExporter returns an initialized Exporter.
@@ -99,7 +99,7 @@ func NewExporter(uri string, kvPrefix string, kvFilter string) *Exporter {
 			[]string{"key"},
 		),
 
-		client: consul_client,
+		client:   consul_client,
 		kvPrefix: kvPrefix,
 		kvFilter: regexp.MustCompile(kvFilter),
 	}
@@ -228,6 +228,10 @@ func (e *Exporter) setMetrics(services <-chan []*consul_api.ServiceEntry) {
 }
 
 func (e *Exporter) setKeyValues() {
+	if e.kvPrefix == "" {
+		return
+	}
+
 	kv := e.client.KV()
 
 	pairs, _, err := kv.List(e.kvPrefix, &consul_api.QueryOptions{})
@@ -251,7 +255,7 @@ func main() {
 		listenAddress = flag.String("web.listen-address", ":9107", "Address to listen on for web interface and telemetry.")
 		metricsPath   = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 		consulServer  = flag.String("consul.server", "localhost:8500", "HTTP API address of a Consul server or agent.")
-		kvPrefix      = flag.String("kv.prefix", "none", "Prefix from which to expose key/value pairs.")
+		kvPrefix      = flag.String("kv.prefix", "", "Prefix from which to expose key/value pairs.")
 		kvFilter      = flag.String("kv.filter", ".*", "Regex that determines which keys to expose.")
 	)
 	flag.Parse()

--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -250,8 +250,8 @@ func main() {
 		listenAddress = flag.String("web.listen-address", ":9107", "Address to listen on for web interface and telemetry.")
 		metricsPath   = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 		consulServer  = flag.String("consul.server", "localhost:8500", "HTTP API address of a Consul server or agent.")
-		kvPrefix      = flag.String("kv.prefix", "none", "Prefix from which to expose key/value pairs")
-		kvFilter      = flag.String("kv.filter", ".*", "Regex that determines which keys to expose")
+		kvPrefix      = flag.String("kv.prefix", "none", "Prefix from which to expose key/value pairs.")
+		kvFilter      = flag.String("kv.filter", ".*", "Regex that determines which keys to expose.")
 	)
 	flag.Parse()
 

--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -76,7 +76,7 @@ func NewExporter(uri string, kvPrefix string, kvFilter string) *Exporter {
 			prometheus.GaugeOpts{
 				Namespace: namespace,
 				Name:      "catalog_service_nodes",
-				Help:      "Number of nodes currently registered for this service",
+				Help:      "Number of nodes currently registered for this service.",
 			},
 			[]string{"service"},
 		),
@@ -94,7 +94,7 @@ func NewExporter(uri string, kvPrefix string, kvFilter string) *Exporter {
 			prometheus.GaugeOpts{
 				Namespace: namespace,
 				Name:      "catalog_kv",
-				Help:      "key/value",
+				Help:      "The values for selected keys in Consul's key/value catalog. Keys with non-numeric values are omitted.",
 			},
 			[]string{"key"},
 		),

--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -233,13 +233,14 @@ func (e *Exporter) setKeyValues() {
 	pairs, _, err := kv.List(e.kvPrefix, &consul_api.QueryOptions{})
 	if err != nil {
 		log.Errorf("Error fetching key/values: %s", err)
-	} else {
-		for _, pair := range pairs {
-			if e.kvFilter.MatchString(pair.Key) {
-				val, err := strconv.ParseFloat(string(pair.Value), 64)
-				if err == nil {
-					e.keyValues.WithLabelValues(pair.Key).Set(val)
-				}
+		return
+	}
+
+	for _, pair := range pairs {
+		if e.kvFilter.MatchString(pair.Key) {
+			val, err := strconv.ParseFloat(string(pair.Value), 64)
+			if err == nil {
+				e.keyValues.WithLabelValues(pair.Key).Set(val)
 			}
 		}
 	}


### PR DESCRIPTION
This appears to work well here. 

I'm not too proficient in go yet so I'd appreciate feedback. 

In particular, I suspect `kv.List` might be blocking so it might be worthwhile to do this as a goroutine that puts the pairs on a channel - on the other hand, if I understand correctly `setMetrics` doesn't do this either, so perhaps it's inconsequential.