### PR TITLE
Export state of all health checks

### DIFF
--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -44,13 +44,9 @@ SRC    ?= $(shell find . -type f -name "*.go" ! -path "./.build/*")
 GOOS   ?= $(shell uname | tr A-Z a-z)
 GOARCH ?= $(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
 
-ifeq ($(GOOS),darwin)
-	RELEASE_SUFFIX ?= -osx$(shell sw_vers -productVersion)
-endif
-
-GO_VERSION ?= 1.4.2
+GO_VERSION ?= 1.5.1
 GOURL      ?= https://golang.org/dl
-GOPKG      ?= go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
+GOPKG      ?= go$(GO_VERSION).$(GOOS)-$(GOARCH).tar.gz
 GOPATH     := $(CURDIR)/.build/gopath
 
 # Check for the correct version of go in the path. If we find it, use it.
@@ -101,7 +97,7 @@ $(BINARY): $(GOCC) $(SRC) dependencies-stamp Makefile Makefile.COMMON
 archive: $(ARCHIVE)
 
 $(ARCHIVE): $(BINARY)
-	tar -czf $@ $<
+	tar --owner=root --group=root -czf $@ $<
 
 .PHONY: tag
 tag:

--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -185,7 +185,6 @@ func (e *Exporter) collect() {
 					break
 				}
 			}
-			log.Infof("%v/%v status is %v", entry.Service.Service, entry.Node.Node, passing)
 			e.serviceNodesHealthy.WithLabelValues(entry.Service.ID, entry.Node.Node).Set(float64(passing))
 		}
 	}
@@ -202,7 +201,6 @@ func (e *Exporter) collect() {
 			if hc.Status != consul.HealthPassing {
 				passing = 0
 			}
-			log.Infof("CHECKS: %v/%v status is %d", hc.CheckID, hc.Node, passing)
 			e.nodeChecks.WithLabelValues(hc.CheckID, hc.Node).Set(float64(passing))
 		}
 	}


### PR DESCRIPTION
We want to know when each individual health check failed so that we can investigate why a particular service wasn't available via service discovery. Therefore, a new metric `consul_health_service_status` was added.

This PR also cleans up several issues with the code and consolidates some other metrics. Most notably:
* `consul_catalog_service_nodes` has been removed as it is redundant (the number of nodes can be calculated with `count()`)
* `consul_catalog_service_node_healthy` uses the service ID instead of the name, as the latter isn't unique and caused metrics to be overwritten.

@ewr @fabxc @brian-brazil 

This PR supersedes #11 which did similar cleanups. It might be easier to review each individual commit.