### PR TITLE
Add Consul port to distinguish labels

### DIFF
--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -202,7 +202,7 @@ func (e *Exporter) setMetrics(services <-chan []*consul_api.ServiceEntry) {
 
 			log.Infof("%v/%v status is %v", entry.Service.Service, entry.Node.Node, passing)
 
-			e.serviceNodesHealthy.WithLabelValues(entry.Service.Service, entry.Node.Node).Set(float64(passing))
+			e.serviceNodesHealthy.WithLabelValues(entry.Service.Service, entry.Node.Node+":"+entry.Port.Port).Set(float64(passing))
 		}
 	}
 }

--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -135,7 +135,7 @@ func (e *Exporter) queryClient(services chan<- []*consul_api.ServiceEntry) {
 
 	if err != nil {
 		e.up.Set(0)
-		log.Printf("Query error is %v", err)
+		log.Errorf("Query error is %v", err)
 		return
 	}
 
@@ -167,7 +167,7 @@ func (e *Exporter) queryClient(services chan<- []*consul_api.ServiceEntry) {
 		s_entries, _, err := e.client.Health().Service(s, "", false, &consul_api.QueryOptions{})
 
 		if err != nil {
-			log.Printf("Failed to query service health: %v", err)
+			log.Errorf("Failed to query service health: %v", err)
 			continue
 		}
 
@@ -200,7 +200,7 @@ func (e *Exporter) setMetrics(services <-chan []*consul_api.ServiceEntry) {
 				}
 			}
 
-			log.Printf("%v/%v status is %v", entry.Service.Service, entry.Node.Node, passing)
+			log.Infof("%v/%v status is %v", entry.Service.Service, entry.Node.Node, passing)
 
 			e.serviceNodesHealthy.WithLabelValues(entry.Service.Service, entry.Node.Node).Set(float64(passing))
 		}
@@ -218,7 +218,7 @@ func main() {
 	exporter := NewExporter(*consulServer)
 	prometheus.MustRegister(exporter)
 
-	log.Printf("Starting Server: %s", *listenAddress)
+	log.Infof("Starting Server: %s", *listenAddress)
 	http.Handle(*metricsPath, prometheus.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>


### PR DESCRIPTION
Instead of only putting the Consul IP address in the Prometheus labels, it is more useful to put the IP:PORT combination in.