### PR TITLE
use ConstMetrics instead of sharing with lock

### DIFF
--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -92,10 +92,12 @@ func NewExporter(uri, kvPrefix, kvFilter string, healthSummary bool) *Exporter {
 // implements prometheus.Collector.
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- up
+	ch <- clusterServers
 	ch <- nodeCount
 	ch <- serviceCount
-	ch <- clusterServers
 	ch <- serviceNodesHealthy
+	ch <- nodeChecks
+	ch <- serviceChecks
 	ch <- keyValues
 }
 


### PR DESCRIPTION
Per some mailing list discussion, I believe this is considered best practice. It's also shorter: since the metrics aren't persistent, there's no need to reset them every time, etc.