### PR TITLE
use scheme if provided to -consul.server flag

### DIFF
--- a/consul_exporter_test.go
+++ b/consul_exporter_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+func TestNewExporter(t *testing.T) {
+	cases := []struct {
+		uri string
+		ok  bool
+	}{
+		{uri: "", ok: false},
+		{uri: "localhost:8500", ok: true},
+		{uri: "https://localhost:8500", ok: true},
+		{uri: "http://some.where:8500", ok: true},
+		{uri: "fuuuu://localhost:8500", ok: false},
+	}
+
+	for _, test := range cases {
+		_, err := NewExporter(test.uri, "", ".*", true)
+		if test.ok && err != nil {
+			t.Errorf("expected no error w/ %s but got %s", test.uri, err)
+		}
+		if !test.ok && err == nil {
+			t.Errorf("expected error w/ %s but got %s", test.uri, err)
+		}
+	}
+}


### PR DESCRIPTION
This preserves existing functionality. If `-consul.server` begins w/ `http://` or `https://` that scheme will be used. HTTP is the fallback scheme if no scheme is provided.

/cc @grobie 