### PR TITLE
Expose /v1/status/leader as a metric

### DIFF
--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
@@ -17,6 +18,7 @@ import (
 
 	consul_api "github.com/hashicorp/consul/api"
 	consul "github.com/hashicorp/consul/consul/structs"
+	"github.com/hashicorp/go-cleanhttp"
 )
 
 const (
@@ -82,7 +84,7 @@ type Exporter struct {
 }
 
 // NewExporter returns an initialized Exporter.
-func NewExporter(uri, kvPrefix, kvFilter string, healthSummary bool) (*Exporter, error) {
+func NewExporter(uri, kvPrefix, kvFilter string, healthSummary bool, consulTimeout time.Duration) (*Exporter, error) {
 	// parse uri to extract scheme
 	if !strings.Contains(uri, "://") {
 		uri = "http://" + uri
@@ -95,10 +97,16 @@ func NewExporter(uri, kvPrefix, kvFilter string, healthSummary bool) (*Exporter,
 		return nil, fmt.Errorf("invalid consul URL: %s", uri)
 	}
 
+	// Use our own http client, with a nice low timeout, so scrapes
+	// don't timeout when talking to a broken consul.
+	httpClient := cleanhttp.DefaultPooledClient()
+	httpClient.Timeout = consulTimeout
+
 	// Set up our Consul client connection.
 	client, _ := consul_api.NewClient(&consul_api.Config{
-		Address: u.Host,
-		Scheme:  u.Scheme,
+		Address:    u.Host,
+		Scheme:     u.Scheme,
+		HttpClient: httpClient,
 	})
 
 	// Init our exporter.
@@ -274,6 +282,7 @@ func main() {
 		healthSummary = flag.Bool("consul.health-summary", true, "Generate a health summary for each service instance. Needs n+1 queries to collect all information.")
 		kvPrefix      = flag.String("kv.prefix", "", "Prefix from which to expose key/value pairs.")
 		kvFilter      = flag.String("kv.filter", ".*", "Regex that determines which keys to expose.")
+		consulTimeout = flag.Duration("consul.timeout", 200*time.Millisecond, "Timeout on HTTP requests to consul")
 	)
 	flag.Parse()
 
@@ -285,7 +294,7 @@ func main() {
 	log.Infoln("Starting consul_exporter", version.Info())
 	log.Infoln("Build context", version.BuildContext())
 
-	exporter, err := NewExporter(*consulServer, *kvPrefix, *kvFilter, *healthSummary)
+	exporter, err := NewExporter(*consulServer, *kvPrefix, *kvFilter, *healthSummary, *consulTimeout)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/consul_exporter_test.go
+++ b/consul_exporter_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestNewExporter(t *testing.T) {
 	cases := []struct {
@@ -15,7 +18,7 @@ func TestNewExporter(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		_, err := NewExporter(test.uri, "", ".*", true)
+		_, err := NewExporter(test.uri, "", ".*", true, 100*time.Millisecond)
 		if test.ok && err != nil {
 			t.Errorf("expected no error w/ %s but got %s", test.uri, err)
 		}


### PR DESCRIPTION
So we can alert when a consul instance doesn't know about its master.