### PR TITLE
Support standard consul api package config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ against the actual value found via monitoring.
 A prefix must be supplied to activate this feature. Pass `/` if you want to
 search the entire keyspace.
 
+## Environment variables
+
+The consul\_exporter supports all environment variables provided by the official
+[consul/api package](https://github.com/hashicorp/consul/blob/c744792fc4d665363dba0ecfc7d05fdedc9cab32/api/api.go#L23-L43),
+including `CONSUL_HTTP_TOKEN` to set the [ACL](https://www.consul.io/docs/internals/acl.html) token.
+
 ## Useful Queries
 
 __Are my services healthy?__


### PR DESCRIPTION
The consul/api package supports several config options to configure
their ACL tokens or also TLS. Instead of reimplementing these options in
the consul_exporter, using their DefaultConfig() intializer allows us to
delegate the implementation and tests to them.

I'll add full integration tests later. Closes #39.

@deepthawtz @discordianfish 