### PR TITLE
Remove mentions of consul_health_service_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ make
 | consul_catalog_services | How many services are in the cluster | |
 | consul_catalog_service_node_healthy | Is this service healthy on this node | service, node |
 | consul_health_node_status | Status of health checks associated with a node | check, node, status |
-| consul_health_service_status | Status of health checks associated with a service | check, node, service, status |
 | consul_catalog_kv | The values for selected keys in Consul's key/value catalog. Keys with non-numeric values are omitted | key |
 
 ### Flags
@@ -37,9 +36,7 @@ make
     the address of a Consul server.
 * __`consul.health-summary`:__ Collects information about each registered
   service and exports `consul_catalog_service_node_healthy`. This requires n+1
-  Consul API queries to gather all information about each service. Health check
-  information are available via `consul_health_service_status` as well, but
-  only for services which have a health check configured. Defaults to true.
+  Consul API queries to gather all information about each service. Defaults to true.
 * __`web.listen-address`:__ Address to listen on for web interface and telemetry.
 * __`web.telemetry-path`:__ Path under which to expose metrics.
 * __`log.level`:__ Logging level. `info` by default.


### PR DESCRIPTION
Delete traces of consul_health_service_status in README because it is no longer available.