### PR TITLE
Apply CONSUL_HTTP_SSL_VERIFY appropriately

### DIFF
--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -105,11 +105,15 @@ func NewExporter(opts consulOpts, kvPrefix, kvFilter string, healthSummary bool)
 		return nil, fmt.Errorf("invalid consul URL: %s", uri)
 	}
 
+	config := consul_api.DefaultConfig()
+	insecureSkipVerify := config.HttpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify
+
 	tlsConfig, err := consul_api.SetupTLSConfig(&consul_api.TLSConfig{
-		Address:  opts.serverName,
-		CAFile:   opts.caFile,
-		CertFile: opts.certFile,
-		KeyFile:  opts.keyFile,
+		Address:            opts.serverName,
+		CAFile:             opts.caFile,
+		CertFile:           opts.certFile,
+		KeyFile:            opts.keyFile,
+		InsecureSkipVerify: insecureSkipVerify,
 	})
 	if err != nil {
 		return nil, err
@@ -117,7 +121,6 @@ func NewExporter(opts consulOpts, kvPrefix, kvFilter string, healthSummary bool)
 	transport := cleanhttp.DefaultPooledTransport()
 	transport.TLSClientConfig = tlsConfig
 
-	config := consul_api.DefaultConfig()
 	config.Address = u.Host
 	config.Scheme = u.Scheme
 	config.HttpClient.Timeout = opts.timeout


### PR DESCRIPTION
This PR fixes the bug that CONSUL_HTTP_SSL_VERIFY will not be applied.

The CONSUL_HTTP_SSL_VERIFY environment variable is applied in the Consul's DefaultConfig(), but the value that applied in DefaultConfig() is overwritten by the assignment of Transport in the current code.