### PR TITLE
Add node metadata and service tags as metrics.

### DIFF
--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -49,7 +49,7 @@ var (
 	)
 	nodeMetaData = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "node_meta_data"),
-		"Tags of a service.",
+		"Node meta data",
 		[]string{"node", "key", "value"}, nil,
 	)
 	serviceCount = prometheus.NewDesc(

--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -47,6 +47,11 @@ var (
 		"How many members are in the cluster.",
 		nil, nil,
 	)
+	nodeMetaData = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "node_meta_data"),
+		"Tags of a service.",
+		[]string{"node", "key", "value"}, nil,
+	)
 	serviceCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "catalog_services"),
 		"How many services are in the cluster.",
@@ -202,6 +207,14 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(
 			nodeCount, prometheus.GaugeValue, float64(len(nodes)),
 		)
+	}
+
+	for _, node := range nodes {
+		for k, v := range node.Meta {
+			ch <- prometheus.MustNewConstMetric(
+				nodeMetaData, prometheus.GaugeValue, 1, node.Node, k, v,
+			)
+		}
 	}
 
 	// Query for the full list of services.


### PR DESCRIPTION
As discussed in #45, I've added service tags as a separate metric. One tag per series.

I've done the same with node metadata. One key/value pair per series.