### PR TITLE
Replacing MAINTAINER instruction with LABEL in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM        quay.io/prometheus/busybox:latest
-MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
+LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 COPY consul_exporter /bin/consul_exporter
 


### PR DESCRIPTION
Replacing MAINTAINER instruction with LABEL in Dockerfile since maintainer is deprecated:
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

Resolves: https://github.com/prometheus/consul_exporter/issues/87