### PR TITLE
Add --consul.insecure flag to skip TLS verification.

### DIFF
--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -96,6 +96,7 @@ type consulOpts struct {
 	keyFile    string
 	serverName string
 	timeout    time.Duration
+	insecure   bool
 }
 
 // NewExporter returns an initialized Exporter.
@@ -113,10 +114,11 @@ func NewExporter(opts consulOpts, kvPrefix, kvFilter string, healthSummary bool)
 	}
 
 	tlsConfig, err := consul_api.SetupTLSConfig(&consul_api.TLSConfig{
-		Address:  opts.serverName,
-		CAFile:   opts.caFile,
-		CertFile: opts.certFile,
-		KeyFile:  opts.keyFile,
+		Address:            opts.serverName,
+		CAFile:             opts.caFile,
+		CertFile:           opts.certFile,
+		KeyFile:            opts.keyFile,
+		InsecureSkipVerify: opts.insecure,
 	})
 	if err != nil {
 		return nil, err
@@ -360,6 +362,7 @@ func main() {
 	kingpin.Flag("consul.key-file", "File path to a PEM-encoded private key used with the certificate to verify the exporter's authenticity.").Default("").StringVar(&opts.keyFile)
 	kingpin.Flag("consul.server-name", "When provided, this overrides the hostname for the TLS certificate. It can be used to ensure that the certificate name matches the hostname we declare.").Default("").StringVar(&opts.serverName)
 	kingpin.Flag("consul.timeout", "Timeout on HTTP requests to consul.").Default("200ms").DurationVar(&opts.timeout)
+	kingpin.Flag("consul.insecure", "Disable TLS host verification.").Default("false").BoolVar(&opts.insecure)
 
 	// Query options.
 	kingpin.Flag("consul.allow_stale", "Allows any Consul server (non-leader) to service a read.").Default("true").BoolVar(&queryOptions.AllowStale)


### PR DESCRIPTION
This patch exposes the InsecureSkipVerify option of the consul TLS configuration via a command-line flag `--consul.insecure`. This defaults to `false`, so the default behaviour is unchanged (full TLS verification).
