### PR TITLE
#143 Handle Consul errors in a consistent fashion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,6 @@ require (
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
 	github.com/hashicorp/memberlist v0.1.4 // indirect
 	github.com/miekg/dns v1.0.15 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/common v0.6.0
 	github.com/sirupsen/logrus v1.4.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
 	github.com/hashicorp/memberlist v0.1.4 // indirect
 	github.com/miekg/dns v1.0.15 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/common v0.6.0
 	github.com/sirupsen/logrus v1.4.2 // indirect


### PR DESCRIPTION
This PR changes the flow of the scraper to not bail out on specific API failures, after `consul` is deemed to be `up`. If one of the `consul` APIs fail, this metric datapoint will be null, which should work well with things like dashboards and/or monitoring (up to the user to treat missing as breaching or not).