### PR TITLE
Add new metric for Consul check names:

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,18 @@ make
 
 ## Exported Metrics
 
-| Metric | Meaning | Labels |
-| ------ | ------- | ------ |
-| consul_up | Was the last query of Consul successful | |
-| consul_raft_peers | How many peers (servers) are in the Raft cluster | |
-| consul_serf_lan_members | How many members are in the cluster | |
-| consul_serf_lan_member_status | Status of member in the cluster. 1=Alive, 2=Leaving, 3=Left, 4=Failed. | member |
-| consul_catalog_services | How many services are in the cluster | |
-| consul_catalog_service_node_healthy | Is this service healthy on this node | service, node |
-| consul_health_node_status | Status of health checks associated with a node | check, node, status |
-| consul_health_service_status | Status of health checks associated with a service | check, node, service, status |
-| consul_catalog_kv | The values for selected keys in Consul's key/value catalog. Keys with non-numeric values are omitted | key |
+| Metric                              | Meaning                                                                                              | Labels                       |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------- |
+| consul_up                           | Was the last query of Consul successful                                                              |                              |
+| consul_raft_peers                   | How many peers (servers) are in the Raft cluster                                                     |                              |
+| consul_serf_lan_members             | How many members are in the cluster                                                                  |                              |
+| consul_serf_lan_member_status       | Status of member in the cluster. 1=Alive, 2=Leaving, 3=Left, 4=Failed.                               | member                       |
+| consul_catalog_services             | How many services are in the cluster                                                                 |                              |
+| consul_catalog_service_node_healthy | Is this service healthy on this node                                                                 | service, node                |
+| consul_health_node_status           | Status of health checks associated with a node                                                       | check, node, status          |
+| consul_health_service_status        | Status of health checks associated with a service                                                    | check, node, service, status |
+| consul_catalog_kv                   | The values for selected keys in Consul's key/value catalog. Keys with non-numeric values are omitted | key                          |
+| consul_service_check_name           | Link the Consul service ID with check name if available                                              | service_id, check_name       |
 
 ### Flags
 

--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ make
 
 ## Exported Metrics
 
-| Metric                              | Meaning                                                                                              | Labels                       |
-| ----------------------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------- |
-| consul_up                           | Was the last query of Consul successful                                                              |                              |
-| consul_raft_peers                   | How many peers (servers) are in the Raft cluster                                                     |                              |
-| consul_serf_lan_members             | How many members are in the cluster                                                                  |                              |
-| consul_serf_lan_member_status       | Status of member in the cluster. 1=Alive, 2=Leaving, 3=Left, 4=Failed.                               | member                       |
-| consul_catalog_services             | How many services are in the cluster                                                                 |                              |
-| consul_catalog_service_node_healthy | Is this service healthy on this node                                                                 | service, node                |
-| consul_health_node_status           | Status of health checks associated with a node                                                       | check, node, status          |
-| consul_health_service_status        | Status of health checks associated with a service                                                    | check, node, service, status |
-| consul_catalog_kv                   | The values for selected keys in Consul's key/value catalog. Keys with non-numeric values are omitted | key                          |
-| consul_service_check_name           | Link the Consul service ID with check name if available                                              | service_id, check_name       |
+| Metric                              | Meaning                                                                                              | Labels                                        |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| consul_up                           | Was the last query of Consul successful                                                              |                                               |
+| consul_raft_peers                   | How many peers (servers) are in the Raft cluster                                                     |                                               |
+| consul_serf_lan_members             | How many members are in the cluster                                                                  |                                               |
+| consul_serf_lan_member_status       | Status of member in the cluster. 1=Alive, 2=Leaving, 3=Left, 4=Failed.                               | member                                        |
+| consul_catalog_services             | How many services are in the cluster                                                                 |                                               |
+| consul_catalog_service_node_healthy | Is this service healthy on this node                                                                 | service, node                                 |
+| consul_health_node_status           | Status of health checks associated with a node                                                       | check, node, status                           |
+| consul_health_service_status        | Status of health checks associated with a service                                                    | check, node, service, status                  |
+| consul_catalog_kv                   | The values for selected keys in Consul's key/value catalog. Keys with non-numeric values are omitted | key                                           |
+| consul_service_checks               | Link the Consul service ID with check name if available                                              | service_id,service_name, check_id, check_name |
 
 ### Flags
 

--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -95,7 +95,7 @@ var (
 	)
 	serviceCheckNames = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "service_checks"),
-		"Link the service id and check name if available",
+		"Link the service id and check name if available.",
 		[]string{"service_id", "service_name", "check_id", "check_name"}, nil,
 	)
 	keyValues = prometheus.NewDesc(
@@ -199,6 +199,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- serviceChecks
 	ch <- keyValues
 	ch <- serviceTag
+	ch <- serviceCheckNames
 }
 
 // Collect fetches the stats from configured Consul location and delivers them

--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -93,6 +93,11 @@ var (
 		"Status of health checks associated with a service.",
 		[]string{"check", "node", "service_id", "service_name", "status"}, nil,
 	)
+	serviceCheckNames = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "service_check_name"),
+		"Link the service id and check name if available",
+		[]string{"service_id", "check_name"}, nil,
+	)
 	keyValues = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "catalog_kv"),
 		"The values for selected keys in Consul's key/value catalog. Keys with non-numeric values are omitted.",
@@ -336,6 +341,9 @@ func (e *Exporter) collectHealthStateMetric(ch chan<- prometheus.Metric) bool {
 			)
 			ch <- prometheus.MustNewConstMetric(
 				serviceChecks, prometheus.GaugeValue, maintenance, hc.CheckID, hc.Node, hc.ServiceID, hc.ServiceName, consul_api.HealthMaint,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				serviceCheckNames, prometheus.GaugeValue, 1, hc.ServiceID, hc.Name,
 			)
 		}
 	}

--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -94,9 +94,9 @@ var (
 		[]string{"check", "node", "service_id", "service_name", "status"}, nil,
 	)
 	serviceCheckNames = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "service_check_name"),
+		prometheus.BuildFQName(namespace, "", "service_checks"),
 		"Link the service id and check name if available",
-		[]string{"service_id", "check_name"}, nil,
+		[]string{"service_id", "service_name", "check_id", "check_name"}, nil,
 	)
 	keyValues = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "catalog_kv"),
@@ -343,7 +343,7 @@ func (e *Exporter) collectHealthStateMetric(ch chan<- prometheus.Metric) bool {
 				serviceChecks, prometheus.GaugeValue, maintenance, hc.CheckID, hc.Node, hc.ServiceID, hc.ServiceName, consul_api.HealthMaint,
 			)
 			ch <- prometheus.MustNewConstMetric(
-				serviceCheckNames, prometheus.GaugeValue, 1, hc.ServiceID, hc.Name,
+				serviceCheckNames, prometheus.GaugeValue, 1, hc.ServiceID, hc.ServiceName, hc.CheckID, hc.Name,
 			)
 		}
 	}

--- a/consul_exporter_test.go
+++ b/consul_exporter_test.go
@@ -139,6 +139,28 @@ consul_catalog_services 3
 				},
 			},
 		},
+		{
+			name: "collect with service check name",
+			metrics: `# HELP consul_catalog_service_node_healthy Is this service healthy on this node?
+# TYPE consul_service_checks gauge
+consul_service_checks{service_id="special",service_name="special",check_id="_nomad-check-special",check_name="friendly-name"} 1
+# HELP consul_service_checks How many services are in the cluster.
+# TYPE consul_catalog_services gauge
+consul_service_checks 1
+`,
+			services: []*consul_api.AgentServiceRegistration{
+				&consul_api.AgentServiceRegistration{
+					ID:   "special",
+					Name: "special",
+					Checks: []*consul_api.AgentServiceCheck{
+						&consul_api.AgentServiceCheck{
+							CheckID: "_nomad-check-special",
+							Name:    "friendly-name",
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			exporter, err := NewExporter(consulOpts{uri: addr, timeout: time.Duration(time.Second)}, "", "", true, log.NewNopLogger())

--- a/consul_exporter_test.go
+++ b/consul_exporter_test.go
@@ -141,12 +141,9 @@ consul_catalog_services 3
 		},
 		{
 			name: "collect with service check name",
-			metrics: `# HELP consul_catalog_service_node_healthy Is this service healthy on this node?
+			metrics: `# HELP consul_service_checks Is there a service with a check name?
 # TYPE consul_service_checks gauge
 consul_service_checks{service_id="special",service_name="special",check_id="_nomad-check-special",check_name="friendly-name"} 1
-# HELP consul_service_checks How many services are in the cluster.
-# TYPE consul_catalog_services gauge
-consul_service_checks 1
 `,
 			services: []*consul_api.AgentServiceRegistration{
 				&consul_api.AgentServiceRegistration{

--- a/consul_exporter_test.go
+++ b/consul_exporter_test.go
@@ -141,9 +141,9 @@ consul_catalog_services 3
 		},
 		{
 			name: "collect with service check name",
-			metrics: `# HELP consul_service_checks Is there a service with a check name?
+			metrics: `# HELP consul_service_checks Link the service id and check name if available.
 # TYPE consul_service_checks gauge
-consul_service_checks{service_id="special",service_name="special",check_id="_nomad-check-special",check_name="friendly-name"} 1
+consul_service_checks{check_id="_nomad-check-special",check_name="friendly-name",service_id="special",service_name="special"} 1
 `,
 			services: []*consul_api.AgentServiceRegistration{
 				&consul_api.AgentServiceRegistration{
@@ -151,8 +151,11 @@ consul_service_checks{service_id="special",service_name="special",check_id="_nom
 					Name: "special",
 					Checks: []*consul_api.AgentServiceCheck{
 						&consul_api.AgentServiceCheck{
-							CheckID: "_nomad-check-special",
-							Name:    "friendly-name",
+							CheckID:  "_nomad-check-special",
+							Name:     "friendly-name",
+							TCP:      "localhost:8080",
+							Timeout:  "30s",
+							Interval: "10s",
 						},
 					},
 				},


### PR DESCRIPTION
My organization would like to surface more human readable check names as an option for quickly identifying an alert for a service check. Check IDs aren't human friendly when seeing the alert from alertmanager.

Signed-off-by: Andrew Cornies <acornies@gmail.com>