### PR TITLE
Configure max connections to consul for the connection pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ make
     TLS certificate. It can be used to ensure that the certificate name matches
     the hostname we declare.
 * __`consul.timeout`:__ Timeout on HTTP requests to consul.
+* __`consul.max-connections`:__ Limit the maximum number of concurrent connections
+    to consul, 0 means no limit. Defaults to 16.
 * __`log.format`:__ Set the log target and format. Example: `logger:syslog?appname=bob&local=7`
     or `logger:stdout?json=true`
 * __`log.level`:__ Logging level. `info` by default.

--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -134,6 +134,7 @@ type consulOpts struct {
 	timeout      time.Duration
 	insecure     bool
 	requestLimit int
+	maxConns     int
 }
 
 // NewExporter returns an initialized Exporter.
@@ -162,6 +163,7 @@ func NewExporter(opts consulOpts, kvPrefix, kvFilter string, healthSummary bool,
 	}
 	transport := cleanhttp.DefaultPooledTransport()
 	transport.TLSClientConfig = tlsConfig
+	transport.MaxConnsPerHost = opts.maxConns
 
 	config := consul_api.DefaultConfig()
 	config.Address = u.Host
@@ -474,6 +476,7 @@ func main() {
 	kingpin.Flag("consul.timeout", "Timeout on HTTP requests to the Consul API.").Default("500ms").DurationVar(&opts.timeout)
 	kingpin.Flag("consul.insecure", "Disable TLS host verification.").Default("false").BoolVar(&opts.insecure)
 	kingpin.Flag("consul.request-limit", "Limit the maximum number of concurrent requests to consul, 0 means no limit.").Default("0").IntVar(&opts.requestLimit)
+	kingpin.Flag("consul.max-connections", "Limit the maximum number of concurrent connections to consul, 0 means no limit.").Default("0").IntVar(&opts.maxConns)
 
 	// Query options.
 	kingpin.Flag("consul.allow_stale", "Allows any Consul server (non-leader) to service a read.").Default("true").BoolVar(&queryOptions.AllowStale)

--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -476,7 +476,7 @@ func main() {
 	kingpin.Flag("consul.timeout", "Timeout on HTTP requests to the Consul API.").Default("500ms").DurationVar(&opts.timeout)
 	kingpin.Flag("consul.insecure", "Disable TLS host verification.").Default("false").BoolVar(&opts.insecure)
 	kingpin.Flag("consul.request-limit", "Limit the maximum number of concurrent requests to consul, 0 means no limit.").Default("0").IntVar(&opts.requestLimit)
-	kingpin.Flag("consul.max-connections", "Limit the maximum number of concurrent connections to consul, 0 means no limit.").Default("0").IntVar(&opts.maxConns)
+	kingpin.Flag("consul.max-connections", "Limit the maximum number of concurrent connections to consul, 0 means no limit.").Default("16").IntVar(&opts.maxConns)
 
 	// Query options.
 	kingpin.Flag("consul.allow_stale", "Allows any Consul server (non-leader) to service a read.").Default("true").BoolVar(&queryOptions.AllowStale)


### PR DESCRIPTION
I'm running into the same issues as described here: https://github.com/prometheus/consul_exporter/issues/102

Unfortunately the fix in https://github.com/prometheus/consul_exporter/pull/164 does not work for us.

When I set the number of `--consul.request-limit` lower than the number of services we have registered in consul (600) then `consul_exporter` just hangs indefinitely. 

I can't explain why the fix does not work for us, but I see a lot of 404's, connection reset by peer and other errors. I think it might have something to do with that, eg that a connection breaks, hangs and does not decrease the limiter.

Anyway, I tried a different approach, by setting a maximum connections on the underlying connection pool. When set on 16 it works fine and also all error messages (404, reset by peer) disappear. 


Anyway, asking for some feedback/thoughts on this.

CC @MaruHyl @simonpasquier @robincw-gr @roidelapluie 
