### PR TITLE
update documentation for disabling cmd-line flag of type bool 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ make
     Consul API queries to gather all information about each service. Health check
     information are available via `consul_health_service_status` as well, but
     only for services which have a health check configured. Defaults to true.
+    Disable using `--no-consul.heatlh-summary`.
 * __`consul.key-file`:__ File path to a PEM-encoded private key used with the
     certificate to verify the exporter's authenticity.
 * __`consul.require_consistent`:__ Forces the read to be fully consistent.


### PR DESCRIPTION
Command-Line argument package `kingpin` uses a unique mechanism to disable bool flags by prefixing with no. As this is non-intuitive and requires some understanding of `kingpin`, suggesting an update in the documentation to better understand how to configure arguments.

enable: `--<name>`
disabled: `--no-<name>`

@simonpasquier 