### PR TITLE
Fix consul_exporter hanging when services > allowed requests

### DIFF
--- a/consul_exporter.go
+++ b/consul_exporter.go
@@ -362,7 +362,7 @@ func (e *Exporter) collectHealthStateMetric(ch chan<- prometheus.Metric) bool {
 // collectHealthSummary collects health information about every node+service
 // combination. It will cause one lookup query per service.
 func (e *Exporter) collectHealthSummary(ch chan<- prometheus.Metric, serviceNames map[string][]string) bool {
-	ok := make(chan bool)
+	ok := make(chan bool, len(serviceNames))
 
 	for s := range serviceNames {
 		if e.requestLimitChan != nil {


### PR DESCRIPTION
When the number of services is > the number of allowed connections, we are blocking on `ok <- e.collectOneHealthSummary(ch, s)` since we only read from that channel further in the function: `allOK = <-ok && allOK`. Setting a size on the channel fixes this.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>