### PR TITLE
Move exporter logic to dedicated package

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -5,6 +5,9 @@ go:
 repository:
     path: github.com/prometheus/consul_exporter
 build:
+    binaries:
+      - name: consul_exporter
+        path: ./cmd/consul_exporter
     flags: -a -tags netgo
     ldflags: |
         -X github.com/prometheus/common/version.Version={{.Version}}

--- a/cmd/consul_exporter/consul_exporter.go
+++ b/cmd/consul_exporter/consul_exporter.go
@@ -1,0 +1,134 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	consul_api "github.com/hashicorp/consul/api"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/promlog"
+	"github.com/prometheus/common/promlog/flag"
+	"github.com/prometheus/common/version"
+	"github.com/prometheus/consul_exporter/pkg/exporter"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type promHTTPLogger struct {
+	logger log.Logger
+}
+
+func (l promHTTPLogger) Println(v ...interface{}) {
+	level.Error(l.logger).Log("msg", fmt.Sprint(v...))
+}
+
+func init() {
+	prometheus.MustRegister(version.NewCollector("consul_exporter"))
+}
+
+func main() {
+	var (
+		listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9107").String()
+		metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
+		healthSummary = kingpin.Flag("consul.health-summary", "Generate a health summary for each service instance. Needs n+1 queries to collect all information.").Default("true").Bool()
+		kvPrefix      = kingpin.Flag("kv.prefix", "Prefix from which to expose key/value pairs.").Default("").String()
+		kvFilter      = kingpin.Flag("kv.filter", "Regex that determines which keys to expose.").Default(".*").String()
+
+		opts         = exporter.ConsulOpts{}
+		queryOptions = consul_api.QueryOptions{}
+	)
+	kingpin.Flag("consul.server", "HTTP API address of a Consul server or agent. (prefix with https:// to connect over HTTPS)").Default("http://localhost:8500").StringVar(&opts.URI)
+	kingpin.Flag("consul.ca-file", "File path to a PEM-encoded certificate authority used to validate the authenticity of a server certificate.").Default("").StringVar(&opts.CAFile)
+	kingpin.Flag("consul.cert-file", "File path to a PEM-encoded certificate used with the private key to verify the exporter's authenticity.").Default("").StringVar(&opts.CertFile)
+	kingpin.Flag("consul.key-file", "File path to a PEM-encoded private key used with the certificate to verify the exporter's authenticity.").Default("").StringVar(&opts.KeyFile)
+	kingpin.Flag("consul.server-name", "When provided, this overrides the hostname for the TLS certificate. It can be used to ensure that the certificate name matches the hostname we declare.").Default("").StringVar(&opts.ServerName)
+	kingpin.Flag("consul.timeout", "Timeout on HTTP requests to the Consul API.").Default("500ms").DurationVar(&opts.Timeout)
+	kingpin.Flag("consul.insecure", "Disable TLS host verification.").Default("false").BoolVar(&opts.Insecure)
+	kingpin.Flag("consul.request-limit", "Limit the maximum number of concurrent requests to consul, 0 means no limit.").Default("0").IntVar(&opts.RequestLimit)
+
+	// Query options.
+	kingpin.Flag("consul.allow_stale", "Allows any Consul server (non-leader) to service a read.").Default("true").BoolVar(&queryOptions.AllowStale)
+	kingpin.Flag("consul.require_consistent", "Forces the read to be fully consistent.").Default("false").BoolVar(&queryOptions.RequireConsistent)
+
+	promlogConfig := &promlog.Config{}
+	flag.AddFlags(kingpin.CommandLine, promlogConfig)
+	kingpin.HelpFlag.Short('h')
+	kingpin.Parse()
+	logger := promlog.New(promlogConfig)
+
+	level.Info(logger).Log("msg", "Starting consul_exporter", "version", version.Info())
+	level.Info(logger).Log("build_context", version.BuildContext())
+
+	exporter, err := exporter.New(opts, queryOptions, *kvPrefix, *kvFilter, *healthSummary, logger)
+	if err != nil {
+		level.Error(logger).Log("msg", "Error creating the exporter", "err", err)
+		os.Exit(1)
+	}
+	prometheus.MustRegister(exporter)
+
+	queryOptionsJson, err := json.MarshalIndent(queryOptions, "", "    ")
+	if err != nil {
+		level.Error(logger).Log("msg", "Error marshaling query options", "err", err)
+		os.Exit(1)
+	}
+
+	http.Handle(*metricsPath,
+		promhttp.InstrumentMetricHandler(
+			prometheus.DefaultRegisterer,
+			promhttp.HandlerFor(
+				prometheus.DefaultGatherer,
+				promhttp.HandlerOpts{
+					ErrorLog: &promHTTPLogger{
+						logger: logger,
+					},
+				},
+			),
+		),
+	)
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>
+             <head><title>Consul Exporter</title></head>
+             <body>
+             <h1>Consul Exporter</h1>
+             <p><a href='` + *metricsPath + `'>Metrics</a></p>
+             <h2>Options</h2>
+             <pre>` + string(queryOptionsJson) + `</pre>
+             </dl>
+             <h2>Build</h2>
+             <pre>` + version.Info() + ` ` + version.BuildContext() + `</pre>
+             </body>
+             </html>`))
+	})
+	http.HandleFunc("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "OK")
+	})
+	http.HandleFunc("/-/ready", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "OK")
+	})
+
+	level.Info(logger).Log("msg", "Listening on address", "address", *listenAddress)
+	if err := http.ListenAndServe(*listenAddress, nil); err != nil {
+		level.Error(logger).Log("msg", "Error starting HTTP server", "err", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/exporter/consul_exporter_test.go
+++ b/pkg/exporter/consul_exporter_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package exporter
 
 import (
 	"bytes"
@@ -40,7 +40,7 @@ func TestNewExporter(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		_, err := NewExporter(consulOpts{uri: test.uri}, "", ".*", true, log.NewNopLogger())
+		_, err := New(ConsulOpts{URI: test.uri}, consul_api.QueryOptions{}, "", ".*", true, log.NewNopLogger())
 		if test.ok && err != nil {
 			t.Errorf("expected no error w/ %q, but got %q", test.uri, err)
 		}
@@ -203,12 +203,12 @@ consul_service_tag{node="{{ .Node }}",service_id="foobar",tag="tag2"} 1
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			exporter, err := NewExporter(
-				consulOpts{
-					uri:          addr,
-					timeout:      time.Duration(time.Second),
-					requestLimit: tc.requestLimit,
-				}, "", "", true, log.NewNopLogger())
+			exporter, err := New(
+				ConsulOpts{
+					URI:          addr,
+					Timeout:      time.Duration(time.Second),
+					RequestLimit: tc.requestLimit,
+				}, consul_api.QueryOptions{}, "", "", true, log.NewNopLogger())
 			if err != nil {
 				t.Errorf("expected no error but got %q", err)
 			}


### PR DESCRIPTION
This allows clients to import the exporter as a library. Corresponds to similar changes made in prometheus/memcached_exporter#97.

Signed-off-by: Robert Fratto <robertfratto@gmail.com>