### PR TITLE
Initial approach for adding meta as metrics

### DIFF
--- a/cmd/consul_exporter/consul_exporter.go
+++ b/cmd/consul_exporter/consul_exporter.go
@@ -51,6 +51,7 @@ func main() {
 		healthSummary = kingpin.Flag("consul.health-summary", "Generate a health summary for each service instance. Needs n+1 queries to collect all information.").Default("true").Bool()
 		kvPrefix      = kingpin.Flag("kv.prefix", "Prefix from which to expose key/value pairs.").Default("").String()
 		kvFilter      = kingpin.Flag("kv.filter", "Regex that determines which keys to expose.").Default(".*").String()
+		metaFilter    = kingpin.Flag("meta.filter", "Regex that determines which meta key/values to expose.").Default("").String()
 
 		opts         = exporter.ConsulOpts{}
 		queryOptions = consul_api.QueryOptions{}
@@ -77,7 +78,7 @@ func main() {
 	level.Info(logger).Log("msg", "Starting consul_exporter", "version", version.Info())
 	level.Info(logger).Log("build_context", version.BuildContext())
 
-	exporter, err := exporter.New(opts, queryOptions, *kvPrefix, *kvFilter, *healthSummary, logger)
+	exporter, err := exporter.New(opts, queryOptions, *kvPrefix, *kvFilter, *metaFilter, *healthSummary, logger)
 	if err != nil {
 		level.Error(logger).Log("msg", "Error creating the exporter", "err", err)
 		os.Exit(1)

--- a/pkg/exporter/consul_exporter_test.go
+++ b/pkg/exporter/consul_exporter_test.go
@@ -40,7 +40,7 @@ func TestNewExporter(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		_, err := New(ConsulOpts{URI: test.uri}, consul_api.QueryOptions{}, "", ".*", true, log.NewNopLogger())
+		_, err := New(ConsulOpts{URI: test.uri}, consul_api.QueryOptions{}, "", ".*", "", true, log.NewNopLogger())
 		if test.ok && err != nil {
 			t.Errorf("expected no error w/ %q, but got %q", test.uri, err)
 		}
@@ -208,7 +208,7 @@ consul_service_tag{node="{{ .Node }}",service_id="foobar",tag="tag2"} 1
 					URI:          addr,
 					Timeout:      time.Duration(time.Second),
 					RequestLimit: tc.requestLimit,
-				}, consul_api.QueryOptions{}, "", "", true, log.NewNopLogger())
+				}, consul_api.QueryOptions{}, "", "", "", true, log.NewNopLogger())
 			if err != nil {
 				t.Errorf("expected no error but got %q", err)
 			}


### PR DESCRIPTION
Related to #196 

I haven't added anything else beyond the basics. I wonder if this is acceptable approach. 

Ideally, I wanted my meta to be exposed like this:

```
consul_service_meta{service_id="...", node="...", key1="value1", key2="value2"} 1
```

However, I wasn't familiar with the Prometheus library. It seems like dynamic labels are bit trickier to make, and I thought maybe this is almost as good:

```
consul_service_meta{service_id="...", node="...", key="key1", value="value1"} 1
consul_service_meta{service_id="...", node="...", key="key2", value="value2"} 1
```

I've also added `metaFilter` parameter which enables filtering which meta keys a user would want to expose.