### PR TITLE
.circleci: update orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  prometheus: prometheus/prometheus@0.15.0
+  prometheus: prometheus/prometheus@0.16.0
 
 executors:
   test:


### PR DESCRIPTION
This is to check that https://github.com/prometheus/circleci/pull/26 works as intended. The rest of the repositories should be updated by the periodic `sync_repo` job but I felt that it would be good to validate end-to-end with one repository.
And from the build job's [logs](https://app.circleci.com/pipelines/github/prometheus/consul_exporter/278/workflows/8516e3ab-83c2-4a32-8258-1c6d117984e1/jobs/849/parallel-runs/0/steps/0-0), the machine executor seems to deploy a supported Ubuntu version.