### PR TITLE
Cleanup golangci-lint errcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,4 +6,9 @@ issues:
 
 linters-settings:
   errcheck:
-    exclude: scripts/errcheck_excludes.txt
+    exclude-functions:
+      # Used in HTTP handlers, any error is handled by the server itself.
+      - (net/http.ResponseWriter).Write
+      # Never check for logger errors.
+      - (github.com/go-kit/log.Logger).Log
+

--- a/scripts/errcheck_excludes.txt
+++ b/scripts/errcheck_excludes.txt
@@ -1,5 +1,0 @@
-// Used in HTTP handlers, any error is handled by the server itself.
-(net/http.ResponseWriter).Write
-
-// Never check for logger errors.
-(github.com/go-kit/log.Logger).Log


### PR DESCRIPTION
Move the errcheck excludes list from an external file to inline in the golangci-lint config file.