### PR TITLE
docs: add consul.agent-only documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ make
 ./consul_exporter --help
 ```
 
+* __`consul.agent-only`:__ Only export metrics about services registered on local agent.
 * __`consul.allow_stale`:__ Allows any Consul server (non-leader) to service
     a read.
 * __`consul.ca-file`:__ File path to a PEM-encoded certificate authority used to


### PR DESCRIPTION
Add missing explanation for `consul.agent-only` in the README.md