### PR TITLE
fixing duplicate services that are seperate only by casing

### DIFF
--- a/pkg/exporter/consul_exporter.go
+++ b/pkg/exporter/consul_exporter.go
@@ -510,7 +510,7 @@ func (e *Exporter) collectOneHealthSummary(ch chan<- prometheus.Metric, serviceN
 			}
 		}
 		if entry.Service.Service != serviceName {
-			level.Warn(e.logger).Log("msg", "Skipping service instance because its registered to %s but belongs to %s service registration", entry.Service.Service, serviceName)
+			level.Debug(e.logger).Log("msg", "Skipping service instance because its registered to %s but belongs to %s service registration", entry.Service.Service, serviceName)
 			break
 		}
 		ch <- prometheus.MustNewConstMetric(

--- a/pkg/exporter/consul_exporter.go
+++ b/pkg/exporter/consul_exporter.go
@@ -509,6 +509,10 @@ func (e *Exporter) collectOneHealthSummary(ch chan<- prometheus.Metric, serviceN
 				break
 			}
 		}
+		if entry.Service.Service != serviceName {
+			level.Warn(e.logger).Log("msg", "Skipping service instance because its registered to %s but belongs to %s service registration", entry.Service.Service, serviceName)
+			break
+		}
 		ch <- prometheus.MustNewConstMetric(
 			serviceNodesHealthy, prometheus.GaugeValue, passing, entry.Service.ID, entry.Node.Node, entry.Service.Service,
 		)


### PR DESCRIPTION
One problem we've experienced is that when you register a service in consul it is case sensitive. so for example, registering 
`redis` and `REDIS` will register 2 services. However the "gotcha" is that instances of _EITHER_ service will tie to _BOTH_ services. 

example:
```
redis service
-------------
instance-1-redis
instance 2-redis
instance-1-REDIS
instance-2-REDIS

REDIS service
-------------
instance-1-REDIS
instance-2-REDIS
instance-1-redis
instance 2-redis
```

This creates duplicate metric entries for consul_service_tag and consul_node_healthy metrics when in reality it shouldn't fail on this. I do say i mostly blame consul for the way its done, but from what i know it was done like that on purpose because that is how the DNS is going to work with consul (case _INSENSITIVE_). 


This simple check looks to make sure the entry/instance (instance-2-*REDIS*)  and its service name matches the service that we are looking up (REDIS service) aka `/v1/health/service/REDIS`. if the instance doesn't match (instance 2-*redis*) we skip it.




