### PR TITLE
Split CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [master, 'release-*']
+    branches: [main, master, 'release-*']
     tags: ['v*']
 
 permissions:
@@ -14,90 +14,53 @@ jobs:
     name: Go tests
     runs-on: ubuntu-latest
     container:
-      # Whenever the Go version is updated here, .promu.yml should also be
-      # updated.
+      # Whenever the Go version is updated here, .promu.yml
+      # should also be updated.
       image: quay.io/prometheus/golang-builder:1.26-base
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - run: make
-      - run: git diff --exit-code
-
-  integration:
-    name: Integration tests (Consul ${{ matrix.consul_version }})
-    runs-on: ubuntu-latest
-    container:
-      # Whenever the Go version is updated here, .promu.yml should also be
-      # updated.
-      image: quay.io/prometheus/golang-builder:1.26-base
-    strategy:
-      matrix:
-        consul_version: ["1.18", "1.21", "1.22"]
-    services:
-      consul:
-        image: hashicorp/consul:${{ matrix.consul_version }}
-        env:
-          CONSUL_LOCAL_CONFIG: '{"node_name":"test"}'
-    env:
-      CONSUL_SERVER: "consul:8500"
-      CONSUL_NODE_NAME: "test"
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - run: |
-          until curl -sf http://consul:8500/v1/agent/self > /dev/null; do sleep 1; done
-          CONSUL_VERSION=$(curl -s http://consul:8500/v1/agent/self | jq -r '.Config.Version')
-          test -n "$CONSUL_VERSION"
-          echo "CONSUL_VERSION=$CONSUL_VERSION" >> $GITHUB_ENV
-      - run: make test GOOPTS=-v
+      - uses: prometheus/promci-setup@5af30ba8c199a91d6c04ebdc3c48e630e355f62d # v0.1.0
+      - run: make GO_ONLY=1 SKIP_GOLANGCI_LINT=1
       - run: git diff --exit-code
 
   build:
-    name: Build consul_exporter for all architectures
+    name: Build
     runs-on: ubuntu-latest
     strategy:
       matrix:
         thread: [ 0, 1, 2, 3]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: prometheus/promci/build@9347e3d5e607933687d9db7af2f23504fe7f893a # v0.6.2
+      - uses: prometheus/promci/build@9c86752f3395e08c57719af549cc455d8e2c2514 # v0.7.0
         with:
           parallelism: 4
           thread: ${{ matrix.thread }}
 
-  publish_main:
-    name: Publish main branch artifacts
+  publish_default:
+    name: Publish default branch artifacts
     runs-on: ubuntu-latest
-    needs: [test_go, integration, build]
-    if: (github.event_name == 'push' && github.event.ref == 'refs/heads/master')
+    needs: [test_go, build]
+    if: |
+      (github.event_name == 'push' && github.event.ref == 'refs/heads/main')
+      ||
+      (github.event_name == 'push' && github.event.ref == 'refs/heads/master')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: prometheus/promci/publish_main@9c86752f3395e08c57719af549cc455d8e2c2514 # v0.7.0
         with:
-          persist-credentials: false
-      - uses: prometheus/promci/publish_main@9347e3d5e607933687d9db7af2f23504fe7f893a # v0.6.2
-        with:
-          docker_hub_login: ${{ secrets.docker_hub_login }}
           docker_hub_password: ${{ secrets.docker_hub_password }}
-          quay_io_login: ${{ secrets.quay_io_login }}
           quay_io_password: ${{ secrets.quay_io_password }}
 
   publish_release:
-    name: Publish release artifacts
+    name: Publish release artefacts
     runs-on: ubuntu-latest
-    needs: [test_go, integration, build]
-    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    needs: [test_go, build]
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: prometheus/promci/publish_release@9c86752f3395e08c57719af549cc455d8e2c2514 # v0.7.0
         with:
-          persist-credentials: false
-      - uses: prometheus/promci/publish_release@9347e3d5e607933687d9db7af2f23504fe7f893a # v0.6.2
-        with:
-          docker_hub_login: ${{ secrets.docker_hub_login }}
           docker_hub_password: ${{ secrets.docker_hub_password }}
-          quay_io_login: ${{ secrets.quay_io_login }}
           quay_io_password: ${{ secrets.quay_io_password }}
           github_token: ${{ secrets.PROMBOT_GITHUB_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,41 @@
+---
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [master, 'release-*']
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    name: Integration tests (Consul ${{ matrix.consul_version }})
+    runs-on: ubuntu-latest
+    container:
+      # Whenever the Go version is updated here, .promu.yml should also be
+      # updated.
+      image: quay.io/prometheus/golang-builder:1.26-base
+    strategy:
+      matrix:
+        consul_version: ["1.18", "1.21", "1.22"]
+    services:
+      consul:
+        image: hashicorp/consul:${{ matrix.consul_version }}
+        env:
+          CONSUL_LOCAL_CONFIG: '{"node_name":"test"}'
+    env:
+      CONSUL_SERVER: "consul:8500"
+      CONSUL_NODE_NAME: "test"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: |
+          until curl -sf http://consul:8500/v1/agent/self > /dev/null; do sleep 1; done
+          CONSUL_VERSION=$(curl -s http://consul:8500/v1/agent/self | jq -r '.Config.Version')
+          test -n "$CONSUL_VERSION"
+          echo "CONSUL_VERSION=$CONSUL_VERSION" >> $GITHUB_ENV
+      - run: make test GOOPTS=-v
+      - run: git diff --exit-code


### PR DESCRIPTION
Split out the integration test into a separate workflow. We don't really need this for releases.